### PR TITLE
Add mission-critical stratagems and custom stratagem support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,14 @@ flamethrower
 autocannon
 railgun
 spear
+seaf_artillery
+prospecting_drill
+super_earth_flag
 sos_beacon
 resupply
 hellbomb
 reinforce
 ```
+
+## Custom commands
+In place of a named command, you can type `+` followed by any combination of `wasd`. For example, `+swaswdsw` would call the Hellbomb the same as `hellbomb` would. Use this in case new stratagems get added.

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,9 @@ fn main() {
         return;
     }
 
+	let valid_custom_chars = vec!['w', 'a', 's', 'd'];
     let mut custom = String::from("");
+
     let command = match args[1].as_str() {
         "test" => "test",
         "machine_gun_sentry" => "swddw",
@@ -74,6 +76,11 @@ fn main() {
         "hellbomb" => "swaswdsw",
         s if s.starts_with("+") => {
             for char in s.chars().skip(1) {
+				if !valid_custom_chars.contains(&char) {
+					println!("Invalid custom character: {}", char);
+					return;
+				}
+			
                 custom.push(char);
             }
             custom.as_str()

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ fn main() {
         "hmg_emplacement" => "swadda",
         "shield_generation_relay" => "swasdd",
         "tesla_tower" => "swdwad",
+        "eagle_rearm" => "wwawd",
         "eagle_strafing_run" => "wdd",
         "eagle_airstrike" => "wdsd",
         "eagle_cluster_bomb" => "wdssd",

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ fn main() {
         return;
     }
 
+    let mut custom = String::from("");
     let command = match args[1].as_str() {
         "test" => "test",
         "machine_gun_sentry" => "swddw",
@@ -63,10 +64,19 @@ fn main() {
         "autocannon" => "saswwd",
         "railgun" => "sdswad",
         "spear" => "sswss",
+        "seaf_artillery" => "dwws",
+        "prospecting_drill" => "ssadss",
+        "super_earth_flag" => "swsw",
         "sos_beacon" => "wsaw",
         "resupply" => "sswd",
         "reinforce" => "wsdaw",
         "hellbomb" => "swaswdsw",
+        s if s.starts_with("+") => {
+            for char in s.chars().skip(1) {
+                custom.push(char);
+            }
+            custom.as_str()
+        },
         _ => {
             println!("Unknown argument: {}", args[1]);
             return;


### PR DESCRIPTION
Added the following mission-critical stratagems:

- seaf_artillery
- prospecting_drill
- super_earth_flag

Also, prefixing any combination of WASD with the `+` sign will also work, allowing this tool to be used with future stratagems without an update.